### PR TITLE
Allow getting readonly propertyValueList

### DIFF
--- a/library/src/commonMain/kotlin/org/jraf/klibnotion/model/property/value/PropertyValue.kt
+++ b/library/src/commonMain/kotlin/org/jraf/klibnotion/model/property/value/PropertyValue.kt
@@ -58,6 +58,8 @@ sealed interface PropertyValue<T> {
 class PropertyValueList {
     internal val propertyValueList = mutableListOf<PropertyValue<*>>()
 
+    fun getAll(): List<PropertyValue<*>> = propertyValueList.toList()
+
     private fun add(propertyValue: PropertyValue<*>): PropertyValueList {
         propertyValueList.add(propertyValue)
         return this


### PR DESCRIPTION
it could be useful if you want optimise your updates this way: 
- get already existing Page, e.g. by its id field
- build PropertyValueList with actual data
- check if Page.propertyValues containsAll PropertyValueList.getAll()
- if so, don't send update request


I create a copy of the original list to ensure it won't be edited manually